### PR TITLE
kasan_symbolize: don't print inlined-to function for inlined frames

### DIFF
--- a/address-sanitizer/tools/kasan_symbolize.py
+++ b/address-sanitizer/tools/kasan_symbolize.py
@@ -175,7 +175,7 @@ class ReportProcesser:
       if len(fileline_parts) >= 2:
         fileline = fileline_parts[1].lstrip('/')
     addr = '     inlined    ';
-    print '%s[<%s>] %s %s %s' % (prefix, addr, body, func, fileline)
+    print '%s[<%s>] %s %s' % (prefix, addr, func, fileline)
 
   def Finalize(self):
     for module, symbolizer in self.module_symbolizers.items():


### PR DESCRIPTION
Currently inlined function name is in the middle of line with lots of text around,
it makes it very difficult to find it visually.

Don't print inlined-to function name for inlined frames,
it makes it much easier to find inlined function name visually.
This info is redundant anyway. Compare:

Before:
     [<     inlined    >] __mutex_init+0x69/0x80 atomic_set ./arch/x86/include/asm/atomic.h:47
     [<     inlined    >] __mutex_init+0x69/0x80 osq_lock_init include/linux/osq_lock.h:29
     [<ffffffff810de949>] __mutex_init+0x69/0x80 kernel/locking/mutex.c:59

After:
     [<     inlined    >] atomic_set ./arch/x86/include/asm/atomic.h:47
     [<     inlined    >] osq_lock_init include/linux/osq_lock.h:29
     [<ffffffff810de949>] __mutex_init+0x69/0x80 kernel/locking/mutex.c:59