### PR TITLE
Add arguments for printing chunks of source code in kernel symbolizer script

### DIFF
--- a/address-sanitizer/tools/kasan_symbolize.py
+++ b/address-sanitizer/tools/kasan_symbolize.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import getopt
 import os
 import re
 import sys
@@ -28,9 +29,6 @@ frame_re = re.compile(
 nm_re = re.compile(
   '^(?P<offset>[0-9A-Fa-f]+) [a-zA-Z] (?P<symbol>[^ ]+)$'
 )
-
-def print_usage():
-  print 'Usage: %s <linux path> [<strip path>]' % sys.argv[0]
 
 class Symbolizer:
   def __init__(self, binary_path):
@@ -64,6 +62,7 @@ class Symbolizer:
     self.proc.wait()
 
 def FindFile(path, name):
+  path = os.path.expanduser(path)
   for root, dirs, files in os.walk(path):
     if name in files:
       return os.path.join(root, name)
@@ -87,12 +86,13 @@ class ReportProcesser:
     self.linux_path = linux_path
     self.module_symbolizers = {}
     self.module_offset_loaders = {}
+    self.loaded_files = {}
 
-  def ProcessInput(self):
+  def ProcessInput(self, lines_before, lines_after):
     for line in sys.stdin:
       line = line.rstrip()
       line = self.StripTime(line)
-      self.ProcessLine(line)
+      self.ProcessLine(line, lines_before, lines_after)
 
   def StripTime(self, line):
     match = time_re.match(line)
@@ -100,7 +100,7 @@ class ReportProcesser:
       line = match.group('body')
     return line
 
-  def ProcessLine(self, line):
+  def ProcessLine(self, line, lines_before, lines_after):
     match = frame_re.match(line)
     if match == None:
       print line
@@ -148,9 +148,11 @@ class ReportProcesser:
       print line
       return
 
-    for frame in frames[:-1]:
-      self.PrintFrame(True, precise, prefix, addr, frame[0], frame[1], body)
-    self.PrintFrame(False, precise, prefix, addr, frames[-1][0], frames[-1][1], body)
+    for i, frame in enumerate(frames):
+      inlined = (i + 1 != len(frames))
+      func, fileline = frame[0], frame[1]
+      self.PrintFrame(inlined, precise, prefix, addr, func, fileline, body)
+      self.PrintLines(fileline, lines_before, lines_after)
 
   def LoadModule(self, module):
     if module in self.module_symbolizers.keys():
@@ -163,6 +165,16 @@ class ReportProcesser:
     self.module_symbolizers[module] = Symbolizer(module_path)
     self.module_offset_loaders[module] = SymbolOffsetLoader(module_path)
     return True
+
+  def LoadFile(self, path):
+    if path in self.loaded_files.keys():
+      return self.loaded_files[path]
+    try:
+      with open(path) as f:
+        self.loaded_files[path] = f.readlines()
+        return self.loaded_files[path]
+    except:
+      return None
 
   def PrintFrame(self, inlined, precise, prefix, addr, func, fileline, body):
     if self.strip_path != None:
@@ -179,19 +191,80 @@ class ReportProcesser:
     else:
       print '%s[<%s>] %s%s %s' % (prefix, addr, precise, body, fileline)
 
+  def PrintLines(self, fileline, lines_before, lines_after):
+    if lines_before == None and lines_after == None:
+      return
+    lines_before = 0 if lines_before == None else lines_before
+    lines_after = 0 if lines_after == None else lines_after
+
+    fileline = fileline.split(':')
+    filename, linenum = fileline[0], fileline[1]
+
+    try:
+      linenum = int(linenum)
+    except:
+      return
+    assert linenum >= 1
+    linenum -= 1
+
+    start = max(0, linenum - lines_before)
+    end = linenum + lines_after + 1
+    lines = self.LoadFile(filename)
+    if not lines:
+      return
+    for line in lines[start:end]:
+      print line,
+
   def Finalize(self):
     for module, symbolizer in self.module_symbolizers.items():
       symbolizer.Close()
 
+def print_usage():
+  print 'Usage: {0} --linux=<linux path>'.format(sys.argv[0]),
+  print '[--strip=<strip path>]',
+  print '[--before=<lines before>]',
+  print '[--after=<lines after>]',
+  print
+
 def main():
-  if len(sys.argv) not in [2, 3]:
+  try:
+    opts, args = getopt.getopt(sys.argv[1:], 'l:s:b:a:',
+		    ['linux=', 'strip=', 'before=', 'after='])
+  except:
     print_usage()
     sys.exit(1)
-  linux_path = sys.argv[1]
-  strip_path = sys.argv[2] if len(sys.argv) == 3 else None
+
+  linux_path = None
+  strip_path = None
+  lines_before = None
+  lines_after = None
+
+  print opts
+  for opt, arg in opts:
+    if opt in ('-l', '--linux'):
+      linux_path = arg
+    elif opt in ('-s', '--strip'):
+      strip_path = arg
+    elif opt in ('-b', '--before'):
+      lines_before = arg
+    elif opt in ('-a', '--after'):
+      lines_after = arg
+
+  if not linux_path:
+    print_usage()
+    sys.exit(1)
+
+  try:
+    lines_before = None if lines_before == None else int(lines_before)
+    lines_after = None if lines_after == None else int(lines_after)
+  except:
+    print_usage()
+    sys.exit(1)
+
   processer = ReportProcesser(linux_path, strip_path)
-  processer.ProcessInput()
+  processer.ProcessInput(lines_before, lines_after)
   processer.Finalize()
+
   sys.exit(0)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also rework some of the existing arguments.
Use --linux to specify the linux kernel path.
Use --strip to specify a filename prefix which will be stripped in each report.
Use --before and --after to specify the number of lines that should be printed
before and after the blamed line.