### PR TITLE
Print line numbers and add padding for code snippets in kernel symbolizer

### DIFF
--- a/address-sanitizer/tools/kasan_symbolize.py
+++ b/address-sanitizer/tools/kasan_symbolize.py
@@ -213,8 +213,9 @@ class ReportProcesser:
     lines = self.LoadFile(filename)
     if not lines:
       return
-    for line in lines[start:end]:
-      print line,
+
+    for i, line in enumerate(lines[start:end]):
+      print '  {0:5d} {1}'.format(i + start + 1, line),
 
   def Finalize(self):
     for module, symbolizer in self.module_symbolizers.items():


### PR DESCRIPTION
Makes report with code snippets much more readable:

```
==================================================================
ThreadSanitizer: data-race in set_state

Write at 0xffff88028e5cfdd0 of size 4 by thread 18 on CPU 3:
 [<ffffffff811557b0>] set_state+0x40/0x50 kernel/stop_machine.c:158
    157         smp_wmb();
    158         msdata->state = newstate;
    159 }
 [<     inline     >] ack_state kernel/stop_machine.c:165
    164         if (atomic_dec_and_test(&msdata->thread_ack))
    165                 set_state(msdata, msdata->state + 1);
    166 }
 [<ffffffff811558f0>] multi_cpu_stop+0x130/0x180 kernel/stop_machine.c:206
    205                         }
    206                         ack_state(msdata);
    207                 }

...
==================================================================
```