### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/address-sanitizer/tools/kasan_symbolize.py
+++ b/address-sanitizer/tools/kasan_symbolize.py
@@ -3,6 +3,7 @@
 # Tool for symbolizing stack traces in BUG reports, mainly those produced
 # by KASAN.
 
+from __future__ import print_function
 from collections import defaultdict
 import getopt
 import os
@@ -170,7 +171,7 @@ class ReportProcessor(object):
             if match:
                 break
         if match == None:
-            print line
+            print(line)
             return
 
         prefix = match.group('prefix')
@@ -183,7 +184,7 @@ class ReportProcessor(object):
         # Don't print frames with '?' until user asked otherwise.
         if not precise and not questionable:
             if '<EOI>' in match.group('prefix'):
-                print match.group('prefix')
+                print(match.group('prefix'))
             return
 
         function = match.group('function')
@@ -197,7 +198,7 @@ class ReportProcessor(object):
             module += '.ko'
 
         if not self.load_module(module):
-            print line
+            print(line)
             return
 
         symbolizer = self.module_symbolizers[module]
@@ -205,7 +206,7 @@ class ReportProcessor(object):
 
         symbol_offset = loader.lookup_offset(function, int(size, 16))
         if symbol_offset is None:
-            print line
+            print(line)
             return
 
         instruction_offset = int(offset, 16)
@@ -214,7 +215,7 @@ class ReportProcessor(object):
         frames = symbolizer.process(module_addr)
 
         if len(frames) == 0:
-            print line
+            print(line)
             return
 
         for i, frame in enumerate(frames):
@@ -258,7 +259,7 @@ class ReportProcessor(object):
         elif addr == None:
             addr = '        none        ';
         precise = '' if precise else '? '
-        print '%s[<%s>] %s%s %s' % (prefix, addr, precise, body, fileline)
+        print('%s[<%s>] %s%s %s' % (prefix, addr, precise, body, fileline))
 
     def print_lines(self, fileline, context_size):
         if context_size == 0:
@@ -282,7 +283,7 @@ class ReportProcessor(object):
             return
 
         for i, line in enumerate(lines[start:end]):
-            print '    {0:5d} {1}'.format(i + start + 1, line),
+            print('    {0:5d} {1}'.format(i + start + 1, line), end=' ')
 
     def finalize(self):
         for module, symbolizer in self.module_symbolizers.items():
@@ -290,12 +291,12 @@ class ReportProcessor(object):
 
 
 def print_usage():
-    print 'Usage: {0} --linux=<linux path>'.format(sys.argv[0]),
-    print '[--strip=<strip path>]',
-    print '[--before=<lines before>]',
-    print '[--after=<lines after>]',
-    print '[--questionable]',
-    print
+    print('Usage: {0} --linux=<linux path>'.format(sys.argv[0]), end=' ')
+    print('[--strip=<strip path>]', end=' ')
+    print('[--before=<lines before>]', end=' ')
+    print('[--after=<lines after>]', end=' ')
+    print('[--questionable]', end=' ')
+    print()
 
 
 def main():

--- a/address-sanitizer/tools/kernel_test_parse.py
+++ b/address-sanitizer/tools/kernel_test_parse.py
@@ -8,6 +8,7 @@ Each test should write special messages to kernel log:
 ##### ASSERT '<regex>' - we should search for the regex in other lines of the
     test's output. If it's not found, the test fails
 """
+from __future__ import print_function
 
 import re
 import sys
@@ -96,38 +97,38 @@ def PrintTestReport(test, run_reports):
     total_result = "FLAKY (%d passed, %d failed, %d total)" % (
                    passed, failed, passed + failed)
   
-  print "TEST %s: %s" % (test, total_result)  
+  print("TEST %s: %s" % (test, total_result))  
   if args.brief:
     return
   for index, (_, failures, failed_asserts, lines) in enumerate(run_reports):
     if not failures and not failed_asserts:
       continue
-    print "  Run %d"   % index
+    print("  Run %d"   % index)
     for f in failures:
-      print "    Failed: %s" % s
+      print("    Failed: %s" % s)
     missing_matches = not args.assert_candidates
     for a in failed_asserts:
-      print "    Failed assert: %s" % a
+      print("    Failed assert: %s" % a)
       if args.assert_candidates:
-        print "    Closest matches:"
+        print("    Closest matches:")
         matches =  difflib.get_close_matches(a, lines, args.assert_candidates, 0.4)
         matches = [match for match in matches if not ASSERT_RE.search(match)]
         for match in matches:
-          print "    " + match
+          print("    " + match)
         if not matches:
           missing_matches = True
     if args.failed_log and (failures or missing_matches):
-      print "    Test log:"
+      print("    Test log:")
       for l in lines:
-        print "        " + l
+        print("        " + l)
 
 def PrintBuildBotAnnotation(passed, failed, flaky, flaky_not_allowed):
   if not passed and not failed and not flaky:
-    print "@@@STEP_TEXT: NO TESTS WERE RUN@@@"
-    print "@@@STEP_FAILURE@@@"
-  print "@@@STEP_TEXT@tests:%d  passed:%d  failed:%d  flaky:%d@@@" % (passed + failed + flaky, passed, failed, flaky)
+    print("@@@STEP_TEXT: NO TESTS WERE RUN@@@")
+    print("@@@STEP_FAILURE@@@")
+  print("@@@STEP_TEXT@tests:%d  passed:%d  failed:%d  flaky:%d@@@" % (passed + failed + flaky, passed, failed, flaky))
   if failed or flaky_not_allowed:
-    print "@@@STEP_FAILURE@@@"
+    print("@@@STEP_FAILURE@@@")
 
 def GroupTests(tests):
   result = {}

--- a/hwaddress-sanitizer/sort_masks.py
+++ b/hwaddress-sanitizer/sort_masks.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 masks = [0,   1,   2,   3,   4,   6,   7,   8,   12,  14,  15, 16,  24,
          28,  30,  31,  32,  48,  56,  60,  62,  63,  64,  96, 112, 120,
          124, 126, 127, 128, 192, 224, 240, 248, 252, 254]
@@ -23,4 +24,4 @@ for i in range(0, 35):
       next_mask = m1
   new_masks += [next_mask]
 
-print new_masks
+print(new_masks)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.