### PR TITLE
Fix TabErrors in Python code

### DIFF
--- a/address-sanitizer/tools/kasan_symbolize.py
+++ b/address-sanitizer/tools/kasan_symbolize.py
@@ -173,11 +173,11 @@ class ReportProcessor(object):
             self.process_line(line, context_size, questionable)
 
     def strip_time(self, line):
-	# Strip time prefix if present.
+        # Strip time prefix if present.
         match = BRACKET_PREFIX_RE.match(line)
         if match != None:
             line = match.group('body')
-	# Try to strip thread/cpu number prefix if present.
+        # Try to strip thread/cpu number prefix if present.
         match = BRACKET_PREFIX_RE.match(line)
         if match != None:
             line = match.group('body')
@@ -195,8 +195,8 @@ class ReportProcessor(object):
             return
 
         prefix = match.group('prefix')
-	try:
-	    addr = match.group('addr')
+        try:
+            addr = match.group('addr')
         except IndexError:
             addr = None
         body = match.group('body')
@@ -213,7 +213,7 @@ class ReportProcessor(object):
         function = match.group('function')
         offset = match.group('offset')
         size = match.group('size')
-	try:
+        try:
             module = match.group('module')
         except IndexError:
             module = None

--- a/address-sanitizer/tools/kernel_test_parse.py
+++ b/address-sanitizer/tools/kernel_test_parse.py
@@ -37,139 +37,139 @@ parser.add_argument("--allow_flaky", nargs = '*', metavar = "name",
 args = parser.parse_args()
 
 def ExtractTestLogs(kernel_log):
-  all_tests = []
-  current_test_lines = []
-  current_test = None
+    all_tests = []
+    current_test_lines = []
+    current_test = None
 
-  for line in sys.stdin:
-    l = line.strip()
-    if current_test:
-      if TEST_END_RE.search(l):
-        all_tests.append((current_test, current_test_lines))
-        current_test = None
-        current_test_lines = []
-      else:
-        current_test_lines.append(l)
-    else:
-      m = TEST_START_RE.search(l)
-      if m:
-        current_test = m.group(1)
-  return all_tests
+    for line in sys.stdin:
+        l = line.strip()
+        if current_test:
+            if TEST_END_RE.search(l):
+                all_tests.append((current_test, current_test_lines))
+                current_test = None
+                current_test_lines = []
+            else:
+                current_test_lines.append(l)
+        else:
+            m = TEST_START_RE.search(l)
+            if m:
+                current_test = m.group(1)
+    return all_tests
 
 def FindFailures(lines):
-  failures = []
-  for l in lines:
-    m = FAIL_RE.search(l)
-    if m:
-      failures.append(m.group(1))
-  return failures
+    failures = []
+    for l in lines:
+        m = FAIL_RE.search(l)
+        if m:
+            failures.append(m.group(1))
+    return failures
 
 def FindAssertFailures(lines):
-  failed_asserts = []
-  for l in lines:
-    m = ASSERT_RE.search(l)
-    if m:
-      current_assert_re = re.compile(m.group(1))
-      has_matches = False
-      for checkedline in lines:
-        if ASSERT_RE.search(checkedline):
-          continue
-        if current_assert_re.search(checkedline):
-          has_matches = True
-          break
-      if not has_matches:
-        failed_asserts.append(current_assert_re.pattern)
-  return failed_asserts
+    failed_asserts = []
+    for l in lines:
+        m = ASSERT_RE.search(l)
+        if m:
+            current_assert_re = re.compile(m.group(1))
+            has_matches = False
+            for checkedline in lines:
+                if ASSERT_RE.search(checkedline):
+                    continue
+                if current_assert_re.search(checkedline):
+                    has_matches = True
+                    break
+            if not has_matches:
+                failed_asserts.append(current_assert_re.pattern)
+    return failed_asserts
 
 def PrintTestReport(test, run_reports):
-  passed = 0
-  failed = 0
-  for result, _, _, _ in run_reports:
-    if result:
-      passed += 1
-    else:
-      failed += 1
-  if passed and not failed:
-    total_result = "PASSED (%d runs)" % passed
-  elif failed and not passed:
-    total_result = "FAILED (%d runs)" % failed
-  else:
-    total_result = "FLAKY (%d passed, %d failed, %d total)" % (
-                   passed, failed, passed + failed)
-  
-  print("TEST %s: %s" % (test, total_result))  
-  if args.brief:
-    return
-  for index, (_, failures, failed_asserts, lines) in enumerate(run_reports):
-    if not failures and not failed_asserts:
-      continue
-    print("  Run %d"   % index)
-    for f in failures:
-      print("    Failed: %s" % s)
-    missing_matches = not args.assert_candidates
-    for a in failed_asserts:
-      print("    Failed assert: %s" % a)
-      if args.assert_candidates:
-        print("    Closest matches:")
-        matches =  difflib.get_close_matches(a, lines, args.assert_candidates, 0.4)
-        matches = [match for match in matches if not ASSERT_RE.search(match)]
-        for match in matches:
-          print("    " + match)
-        if not matches:
-          missing_matches = True
-    if args.failed_log and (failures or missing_matches):
-      print("    Test log:")
-      for l in lines:
-        print("        " + l)
-
-def PrintBuildBotAnnotation(passed, failed, flaky, flaky_not_allowed):
-  if not passed and not failed and not flaky:
-    print("@@@STEP_TEXT: NO TESTS WERE RUN@@@")
-    print("@@@STEP_FAILURE@@@")
-  print("@@@STEP_TEXT@tests:%d  passed:%d  failed:%d  flaky:%d@@@" % (passed + failed + flaky, passed, failed, flaky))
-  if failed or flaky_not_allowed:
-    print("@@@STEP_FAILURE@@@")
-
-def GroupTests(tests):
-  result = {}
-  for test, lines in tests:
-    if test not in result:
-      result[test] = []
-    result[test].append(lines)
-  return result  
-
-def main():
-  all_tests = ExtractTestLogs(sys.stdin)
-  grouped_tests = GroupTests(all_tests)
-
-  total_passed = 0
-  total_failed = 0
-  total_flaky = 0
-  flaky_not_allowed = False
-  for test, runs in grouped_tests.iteritems():
     passed = 0
     failed = 0
-    run_reports = []
-    for lines in runs:
-      failed_asserts = FindAssertFailures(lines)
-      failures = FindFailures(lines)
-      if failed_asserts or failures:
-        failed += 1
-      else:
-        passed += 1
-      run_reports.append((not failed_asserts and not failures, failures, failed_asserts, lines))
+    for result, _, _, _ in run_reports:
+        if result:
+            passed += 1
+        else:
+            failed += 1
     if passed and not failed:
-      total_passed += 1
+        total_result = "PASSED (%d runs)" % passed
     elif failed and not passed:
-      total_failed += 1
+        total_result = "FAILED (%d runs)" % failed
     else:
-      total_flaky += 1
-      if not args.allow_flaky or (test not in args.allow_flaky):
-	flaky_not_allowed = True
-    PrintTestReport(test, run_reports)
+        total_result = "FLAKY (%d passed, %d failed, %d total)" % (
+                       passed, failed, passed + failed)
 
-  if args.annotate:
-    PrintBuildBotAnnotation(total_passed, total_failed, total_flaky, flaky_not_allowed)
+    print("TEST %s: %s" % (test, total_result))
+    if args.brief:
+        return
+    for index, (_, failures, failed_asserts, lines) in enumerate(run_reports):
+        if not failures and not failed_asserts:
+            continue
+        print("  Run %d"   % index)
+        for f in failures:
+            print("    Failed: %s" % f)
+        missing_matches = not args.assert_candidates
+        for a in failed_asserts:
+            print("    Failed assert: %s" % a)
+            if args.assert_candidates:
+                print("    Closest matches:")
+                matches =  difflib.get_close_matches(a, lines, args.assert_candidates, 0.4)
+                matches = [match for match in matches if not ASSERT_RE.search(match)]
+                for match in matches:
+                    print("    " + match)
+                if not matches:
+                    missing_matches = True
+        if args.failed_log and (failures or missing_matches):
+            print("    Test log:")
+            for l in lines:
+                print("        " + l)
+
+def PrintBuildBotAnnotation(passed, failed, flaky, flaky_not_allowed):
+    if not passed and not failed and not flaky:
+        print("@@@STEP_TEXT: NO TESTS WERE RUN@@@")
+        print("@@@STEP_FAILURE@@@")
+    print("@@@STEP_TEXT@tests:%d  passed:%d  failed:%d  flaky:%d@@@" % (passed + failed + flaky, passed, failed, flaky))
+    if failed or flaky_not_allowed:
+        print("@@@STEP_FAILURE@@@")
+
+def GroupTests(tests):
+    result = {}
+    for test, lines in tests:
+        if test not in result:
+            result[test] = []
+        result[test].append(lines)
+    return result
+
+def main():
+    all_tests = ExtractTestLogs(sys.stdin)
+    grouped_tests = GroupTests(all_tests)
+
+    total_passed = 0
+    total_failed = 0
+    total_flaky = 0
+    flaky_not_allowed = False
+    for test, runs in grouped_tests.iteritems():
+        passed = 0
+        failed = 0
+        run_reports = []
+        for lines in runs:
+            failed_asserts = FindAssertFailures(lines)
+            failures = FindFailures(lines)
+            if failed_asserts or failures:
+                failed += 1
+            else:
+                passed += 1
+            run_reports.append((not failed_asserts and not failures, failures, failed_asserts, lines))
+        if passed and not failed:
+            total_passed += 1
+        elif failed and not passed:
+            total_failed += 1
+        else:
+            total_flaky += 1
+            if not args.allow_flaky or (test not in args.allow_flaky):
+                flaky_not_allowed = True
+        PrintTestReport(test, run_reports)
+
+    if args.annotate:
+        PrintBuildBotAnnotation(total_passed, total_failed, total_flaky, flaky_not_allowed)
 
 if __name__ == '__main__':
-  main()
+    main()


### PR DESCRIPTION
Python 3 treats the mixing of space and tab indentation as a syntax error called a TabError.