### PR TITLE
Create QEMU image in buildbot startup script.

### DIFF
--- a/buildbot/start_script.sh
+++ b/buildbot/start_script.sh
@@ -35,17 +35,23 @@ mount -t tmpfs tmpfs -o size=80% $BOT_DIR
 
       apt-get install -qq -y \
         automake \
+        bc \
         binutils-dev \
         binutils-gold \
+        bison \
         buildbot-worker \
         ccache \
         cmake \
+        debootstrap \
         dos2unix \
+        e2fsprogs \
+        flex \
         g++ \
         g++-multilib \
         gawk \
         gcc-multilib \
         git \
+        libelf-dev \
         libfdt-dev \
         libgcrypt-dev \
         libglib2.0-dev \
@@ -59,7 +65,9 @@ mount -t tmpfs tmpfs -o size=80% $BOT_DIR
         libxml2-dev \
         libstdc++-dev-*-cross \
         m4 \
+        make \
         ninja-build \
+        openssh-client \
         pkg-config \
         python-dev \
         python-psutil \
@@ -80,6 +88,26 @@ mount -t tmpfs tmpfs -o size=80% $BOT_DIR
 
 update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20
 update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10
+
+# Generate Debian image for QEMU bot.
+mkdir -p $BOT_DIR/qemu_image
+(
+  set -eux
+  cd $BOT_DIR/qemu_image
+
+  SLEEP=0
+  for i in `seq 1 5`; do
+    sleep $SLEEP
+    SLEEP=$(( SLEEP + 10))
+
+    rm -f *
+    (
+      curl "https://raw.githubusercontent.com/google/sanitizers/master/hwaddress-sanitizer/create_qemu_image.sh" \
+        | bash
+    ) && exit 0
+  done
+  exit 1
+) || $ON_ERROR
 
 SERVICE_NAME=buildbot-worker@b.service
 [[ -d /var/lib/buildbot/workers/b ]] || ln -s $BOT_DIR /var/lib/buildbot/workers/b

--- a/hwaddress-sanitizer/create_qemu_image.sh
+++ b/hwaddress-sanitizer/create_qemu_image.sh
@@ -31,22 +31,22 @@ echo "nameserver 8.8.8.8" >> "${IMAGE_DIR}/etc/resolve.conf"
 echo "debian" > "${IMAGE_DIR}/etc/hostname"
 
 # Set up SSH.
-ssh-keygen -f "${RELEASE}.id_rsa" -t rsa -N ""
+ssh-keygen -f "debian.id_rsa" -t rsa -N ""
 mkdir -p "${IMAGE_DIR}/root/.ssh/"
-cat "${RELEASE}.id_rsa.pub" > "${IMAGE_DIR}/root/.ssh/authorized_keys"
+cat "debian.id_rsa.pub" > "${IMAGE_DIR}/root/.ssh/authorized_keys"
 
 # Configure for HWASan tests.
 mkdir -p "${IMAGE_DIR}/workspace"
 
 # Build disk image.
-dd if=/dev/zero of="${RELEASE}.img" bs=1M seek=2047 count=1
-mkfs.ext4 -F "${RELEASE}.img"
+dd if=/dev/zero of="debian.img" bs=1M seek=2047 count=1
+mkfs.ext4 -F "debian.img"
 mkdir -p "/mnt/${RELEASE}"
-mount -o loop "${RELEASE}.img" "/mnt/${RELEASE}"
+mount -o loop "debian.img" "/mnt/${RELEASE}"
 cp -a "${IMAGE_DIR}/." "/mnt/${RELEASE}/."
 umount "/mnt/${RELEASE}"
 rm -r "/mnt/${RELEASE}"
 
 # Allow non-root user to access outputs.
-chmod 644 "${RELEASE}.id_rsa"
-chmod 666 "${RELEASE}.img"
+chmod 644 "debian.id_rsa"
+chmod 666 "debian.img"


### PR DESCRIPTION
Add necessary packages to test HWASan+LAM:
- `debootstrap`, `e2fsprogs`, and `openssh-client` for generating the QEMU image.
- `bc`, `bison`, `flex`, `libelf-dev`, and `make` for building the custom kernel.

Build the QEMU image and place it in `/b/qemu_image` for use by the
llvm-zorg script.

Also make some minor changes to `create_qemu_image.sh` for simpler
integration with the llvm-zorg script (we can avoid changing the name of
the Debian image when we upgrade to a new release).