### PR TITLE
Make sure ModuleCache does not grow over time.

### DIFF
--- a/buildbot/install_deps.sh
+++ b/buildbot/install_deps.sh
@@ -94,6 +94,9 @@ sudo service stackdriver-agent start
 update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20
 update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10
 
+# Make sure /var/lib/buildbot/.cache/clang/ModuleCache/ does not grow over time.
+rm -rf /var/lib/buildbot/.cache/clang
+
 mkdir -p /var/lib/buildbot/.ccache
 chown -R buildbot:buildbot /var/lib/buildbot/.ccache
 cat <<EOF >/var/lib/buildbot/.ccache/ccache.conf


### PR DESCRIPTION
Buildbots failing with:
`fatal error: error in backend: IO failure on output stream: No space left on device`

/var/lib/buildbot/.cache/clang/ModuleCache/ is growing over time, across builds.