### PR TITLE
fix: correct resolv.conf filename to include nameserver configuration

### DIFF
--- a/hwaddress-sanitizer/create_qemu_image.sh
+++ b/hwaddress-sanitizer/create_qemu_image.sh
@@ -50,7 +50,7 @@ EOF
 
 echo "/dev/root / ext4 defaults 0 0" >> "${IMAGE_DIR}/etc/fstab"
 echo -en "127.0.0.1\tlocalhost\n" > "${IMAGE_DIR}/etc/hosts"
-echo "nameserver 8.8.8.8" >> "${IMAGE_DIR}/etc/resolve.conf"
+echo "nameserver 8.8.8.8" >> "${IMAGE_DIR}/etc/resolv.conf"
 echo "debian" > "${IMAGE_DIR}/etc/hostname"
 
 # Set up SSH.


### PR DESCRIPTION
**PR Summary**:
The PR contains a simple fix to typo found in the `hwaddress-sanitizer/create_qemu_image.sh` file. Instead `/etc/resolve.conf` it should be `/etc/resolv.conf`. Otherwise, it leads to nameserver configuration issues.